### PR TITLE
Add IDE folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /build/
 /dist/
 /swcpm.egg-info/
+/.idea/


### PR DESCRIPTION
Add .idea folder to gitignore so that it won't be pushed to Git anymore. An idea file contains system-specific content and might mess up the project for others downloading the repo